### PR TITLE
Fix sponsors list margin

### DIFF
--- a/source/assets/stylesheets/_sponsors.scss
+++ b/source/assets/stylesheets/_sponsors.scss
@@ -13,19 +13,12 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      margin-right: 20px;
+      margin-right: 10px;
+      margin-left: 10px;
       margin-bottom: 20px;
       padding: 10px;
       background-color: #fff;
       border: 1px solid #eee;
-
-      @media (max-width: $screen-xs-max) {
-        margin-right: 0;
-      }
-
-      &:last-child {
-        margin-right: 0;
-      }
 
       img {
         max-width: 100%;


### PR DESCRIPTION
@fullvirtue スポンサーリストのmarginのとり方の問題で2段目以降がずれていた件を修正しました。
確認の上問題なければmergeしてください :pray:

Before
![image](https://user-images.githubusercontent.com/732828/31594501-35690a96-b270-11e7-99a8-21c4c256a650.png)

After
![image](https://user-images.githubusercontent.com/732828/31594486-2554fcb4-b270-11e7-9174-46450e29c479.png)
